### PR TITLE
Add paging to getlasttxs API call

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 const express = require('express'),
+  debug = require('debug')('explorer'),
   path = require('path'),
   bitcoinapi = require('bitcoin-node-api'),
   favicon = require('static-favicon'),
@@ -109,10 +110,13 @@ app.use('/ext/getdistribution', function(req,res){
   });
 });
 
-app.use('/ext/getlasttxs/:min', function(req,res){
-  db.get_last_txs(settings.index.last_txs, (req.params.min * 100000000), function(txs){
-    res.send({data: txs});
-  });
+app.use('/ext/getlasttxs', function (req, res) {
+  return db.get_last_txs(parseInt(req.query.count) || settings.index.last_txs, req.query.minAmount * 100000000, req.query.start).then(txs =>
+    res.send({data: txs})
+  ).catch(err => {
+    debug(err)
+    res.send({ error: `An error occurred: ${err}` })
+  })
 });
 
 app.use('/ext/connections', function(req,res){

--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,7 @@
   "index": {
     "show_hashrate": true,
     "difficulty": "POW",
-    "last_txs": 100
+    "last_txs": 1000
   },
   "api": {
     "blockindex": 1337,

--- a/lib/database.js
+++ b/lib/database.js
@@ -365,14 +365,16 @@ module.exports = {
     });
   },
 
-  get_last_txs: function(count, min, cb) {
-    Tx.find({'total': {$gt: min}}).sort({_id: 'desc'}).limit(count).exec(function(err, txs){
-      if (err) {
-        return cb(err);
-      } else {
-        return cb(txs);
-      }
-    });
+  get_last_txs (count, minAmount, start) {
+    return new Promise((resolve, reject) => {
+      Tx.find(Object.assign({ 'total': { $gt: minAmount } }, start ? { '_id': { $lt: start } } : {} ))
+        .sort({ '_id': 'desc' })
+        .limit(count)
+        .exec((err, txs) => {
+          if (err) reject(err)
+          else resolve(txs)
+        })
+    })
   },
 
   create_market: function(coin, exchange, market, cb) {

--- a/views/index.jade
+++ b/views/index.jade
@@ -21,12 +21,12 @@ block content
           }
         },
         columns: [
-          //{ data: 'height', width: '8%' },
+          { data: 'blockcount', width: '8%' },
           { data: 'difficulty', width: '10%' },
-          //{ data: 'size', width:'10%' },
-          //{ data: 'txs', width: '10%' },
+          //- { data: 'size', width:'10%' },
+          //- { data: 'txs', width: '10%' },
           { data: 'supply', width: '15%' },
-          //{ data: 'time', width: '20%' },
+          //- { data: 'time', width: '20%' },
         ]
       });
       var rtable = $('#recent-table').dataTable( {  
@@ -37,7 +37,7 @@ block content
         lengthChange: true,
         processing: true,
         ajax: {
-          url: '/ext/getlasttxs/0.00000001',
+          url: '/ext/getlasttxs?minAmount=0.00000001',
           dataSrc: function ( json ) {
             for ( var i=0;i<json.data.length; i++ ) {
               json.data[i]['timestamp'] = new Date((json.data[i]['timestamp']) * 1000).toUTCString();

--- a/views/info.jade
+++ b/views/info.jade
@@ -94,7 +94,7 @@ block content
 
           *  **getdistribution**  
                *Returns wealth distribution stats*  
-               [#{address}/ext/getdistribution](/ext/getdistribution)               
+               [#{address}/ext/getdistribution](/ext/getdistribution)
 
           *  **getaddress (/ext/getaddress/hash)**  
                *Returns information for given address*  
@@ -104,10 +104,10 @@ block content
                *Returns current balance of given address*  
                [#{address}/ext/getbalance/#{hashes.address}](/ext/getbalance/#{hashes.address})
 
-          *  **getlasttxs (/ext/getlasttxs/count/min)**  
-               *Returns last [count] transactions greater than [min]*  
+          *  **getlasttxs (/ext/getlasttxs?count=[number\_of\_txs]&minAmount=[min\_amount\_in\_#{settings.symbol}]&start=[most\_recent\_tx\_objectid])**  
+               *Returns last [count] transactions with amounts (measured in #{settings.symbol}) greater than [minAmount]. Start is mainly used for paging results such that if specified, only transactions with objectIds less than [start] will be returned. Since objectIds are created according to when the transaction was added to the database, they essentially serve as a unique timestamp to query by.*  
                *Note: returned values are in satoshis*  
-               [#{address}/ext/getlasttxs/10/100](/ext/getlasttxs/10/100)
+               [#{address}/ext/getlasttxs?count=10&minAmount=5](/ext/getlasttxs?count=10&minAmount=5)
 
           ------
 

--- a/views/movement.jade
+++ b/views/movement.jade
@@ -38,7 +38,7 @@ block content
         lengthChange: false,
         //processing: true,
         ajax: {
-          url: '/ext/getlasttxs/#{min_amount}',
+          url: '/ext/getlasttxs?minAmount=#{min_amount}',
           dataSrc: function ( json ) {
             for ( var i=0;i<json.data.length; i++ ) {
               json.data[i]['timestamp'] = format_unixtime(json.data[i]['timestamp']);


### PR DESCRIPTION
Since fixing the issue where only the latest 100 transactions is going back in the backlog. I just added the ability page transactions. This means that when browsing for transactions, you don't have to get all transactions from 0 to count (0 being the newest, and count being number of transactions you want). I also increased the number of transactions loaded from 100 to 1000 just for qa so we can still see all the transactions. 